### PR TITLE
Standalone server

### DIFF
--- a/lib/boombox/application.ex
+++ b/lib/boombox/application.ex
@@ -1,27 +1,34 @@
 defmodule Boombox.Application do
   @moduledoc """
-  Boombox application. When released as a standalone server will start Boombox.Server under the
-  supervision tree.
+  Boombox application. If released with release name set to `"server"`, Boombox.Server under the
+  supervision tree. If `NODE_TO_PING` environment variable is set, then a node with the provided
+  name will be pinged.
   """
   use Application
 
   @impl true
   def start(_type, _args) do
-    children =
-      case System.get_env("RELEASE_NAME") do
-        "server" ->
-          node_to_ping = System.get_env("NODE_TO_PING")
+    case System.fetch_env("RELEASE_NAME") do
+      {:ok, "server"} ->
+        start_server()
 
-          if node_to_ping != nil do
-            Node.ping(String.to_atom(node_to_ping))
-          end
+      _not_server ->
+        Supervisor.start_link([], strategy: :one_for_one)
+    end
+  end
 
-          [Boombox.Server]
+  defp start_server() do
+    case System.fetch_env("NODE_TO_PING") do
+      :error ->
+        :ok
 
-        _not_server ->
-          []
-      end
+      {:ok, node_to_ping} ->
+        case Node.ping(String.to_atom(node_to_ping)) do
+          :pong -> :ok
+          :pang -> raise "Connection with node #{node_to_ping} failed."
+        end
+    end
 
-    Supervisor.start_link(children, strategy: :one_for_one)
+    Supervisor.start_link([Boombox.Server], strategy: :one_for_one)
   end
 end

--- a/lib/boombox/application.ex
+++ b/lib/boombox/application.ex
@@ -1,6 +1,6 @@
 defmodule Boombox.Application do
   @moduledoc """
-  Boombox application. When released as a standalone server will start `Boombox.Server` under the
+  Boombox application. When released as a standalone server will start Boombox.Server under the
   supervision tree.
   """
   use Application

--- a/lib/boombox/application.ex
+++ b/lib/boombox/application.ex
@@ -1,4 +1,8 @@
 defmodule Boombox.Application do
+  @moduledoc """
+  Boombox application. When released as a standalone server will start `Boombox.Server` under the
+  supervision tree.
+  """
   use Application
 
   @impl true

--- a/lib/boombox/application.ex
+++ b/lib/boombox/application.ex
@@ -1,8 +1,8 @@
 defmodule Boombox.Application do
   @moduledoc """
-  Boombox application. If released with release name set to `"server"`, Boombox.Server under the
-  supervision tree. If `NODE_TO_PING` environment variable is set, then a node with the provided
-  name will be pinged.
+  Boombox application. If released with release name set to `"server"`, Boombox.Server will be
+  started under the supervision tree. If `BOOMBOX_NODE_TO_PING` environment variable is set,
+  then a node with the provided name will be pinged.
   """
   use Application
 
@@ -18,7 +18,7 @@ defmodule Boombox.Application do
   end
 
   defp start_server() do
-    case System.fetch_env("NODE_TO_PING") do
+    case System.fetch_env("BOOMBOX_NODE_TO_PING") do
       :error ->
         :ok
 

--- a/lib/boombox/application.ex
+++ b/lib/boombox/application.ex
@@ -1,0 +1,23 @@
+defmodule Boombox.Application do
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children =
+      case System.get_env("RELEASE_NAME") do
+        "server" ->
+          node_to_ping = System.get_env("NODE_TO_PING")
+
+          if node_to_ping != nil do
+            Node.ping(String.to_atom(node_to_ping))
+          end
+
+          [Boombox.Server]
+
+        _not_server ->
+          []
+      end
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end

--- a/lib/boombox/internal_bin/elixir_stream.ex
+++ b/lib/boombox/internal_bin/elixir_stream.ex
@@ -31,14 +31,7 @@ defmodule Boombox.InternalBin.ElixirStream do
            |> via_out(Pad.ref(:output, :audio))}
       end)
 
-    audio_options =
-      case Map.take(options, @options_audio_keys) do
-        empty_audio_options when map_size(empty_audio_options) == 0 -> nil
-        audio_options -> audio_options
-      end
-
-    spec_builder =
-      child(:elixir_stream_source, %Source{producer: producer, audio_options: audio_options})
+    spec_builder = child(:elixir_stream_source, %Source{producer: producer})
 
     %Ready{track_builders: builders, spec_builder: spec_builder}
   end

--- a/lib/boombox/internal_bin/elixir_stream.ex
+++ b/lib/boombox/internal_bin/elixir_stream.ex
@@ -1,8 +1,4 @@
-<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream.ex
 defmodule Boombox.InternalBin.ElixirStream do
-=======
-defmodule Boombox.ElixirStream do
->>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream.ex
   @moduledoc false
 
   import Membrane.ChildrenSpec

--- a/lib/boombox/internal_bin/elixir_stream.ex
+++ b/lib/boombox/internal_bin/elixir_stream.ex
@@ -1,4 +1,8 @@
+<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream.ex
 defmodule Boombox.InternalBin.ElixirStream do
+=======
+defmodule Boombox.ElixirStream do
+>>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream.ex
   @moduledoc false
 
   import Membrane.ChildrenSpec

--- a/lib/boombox/internal_bin/elixir_stream.ex
+++ b/lib/boombox/internal_bin/elixir_stream.ex
@@ -35,8 +35,14 @@ defmodule Boombox.ElixirStream do
            |> via_out(Pad.ref(:output, :audio))}
       end)
 
+    audio_options =
+      case Map.take(options, @options_audio_keys) do
+        audio_options when map_size(audio_options) == 3 -> audio_options
+        _no_audio_options -> nil
+      end
+
     spec_builder =
-      child(:elixir_stream_source, %Source{producer: producer})
+      child(:elixir_stream_source, %Source{producer: producer, audio_options: audio_options})
 
     %Ready{track_builders: builders, spec_builder: spec_builder}
   end

--- a/lib/boombox/internal_bin/elixir_stream.ex
+++ b/lib/boombox/internal_bin/elixir_stream.ex
@@ -33,8 +33,8 @@ defmodule Boombox.InternalBin.ElixirStream do
 
     audio_options =
       case Map.take(options, @options_audio_keys) do
-        audio_options when map_size(audio_options) == 3 -> audio_options
-        _no_audio_options -> nil
+        empty_audio_options when map_size(empty_audio_options) == 0 -> nil
+        audio_options -> audio_options
       end
 
     spec_builder =

--- a/lib/boombox/internal_bin/elixir_stream/sink.ex
+++ b/lib/boombox/internal_bin/elixir_stream/sink.ex
@@ -1,4 +1,8 @@
+<<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream/sink.ex
 defmodule Boombox.InternalBin.ElixirStream.Sink do
+========
+defmodule Boombox.ElixirStream.Sink do
+>>>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream/sink.ex
   @moduledoc false
   use Membrane.Sink
 

--- a/lib/boombox/internal_bin/elixir_stream/sink.ex
+++ b/lib/boombox/internal_bin/elixir_stream/sink.ex
@@ -28,12 +28,18 @@ defmodule Boombox.InternalBin.ElixirStream.Sink do
 
   @impl true
   def handle_info(:boombox_demand, ctx, state) do
-    {kind, _pts} =
+    available_pads =
       state.last_pts
       |> Enum.reject(fn {kind, _pts} -> ctx.pads[Pad.ref(:input, kind)].end_of_stream? end)
-      |> Enum.min_by(fn {_kind, pts} -> pts end)
 
-    {[demand: Pad.ref(:input, kind)], state}
+    if available_pads == [] do
+      {[], state}
+    else
+      {kind, _pts} =
+        Enum.min_by(available_pads, fn {_kind, pts} -> pts end)
+
+      {[demand: Pad.ref(:input, kind)], state}
+    end
   end
 
   @impl true

--- a/lib/boombox/internal_bin/elixir_stream/sink.ex
+++ b/lib/boombox/internal_bin/elixir_stream/sink.ex
@@ -1,8 +1,4 @@
-<<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream/sink.ex
 defmodule Boombox.InternalBin.ElixirStream.Sink do
-========
-defmodule Boombox.ElixirStream.Sink do
->>>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream/sink.ex
   @moduledoc false
   use Membrane.Sink
 

--- a/lib/boombox/internal_bin/elixir_stream/sink.ex
+++ b/lib/boombox/internal_bin/elixir_stream/sink.ex
@@ -31,8 +31,12 @@ defmodule Boombox.ElixirStream.Sink do
   end
 
   @impl true
-  def handle_info(:boombox_demand, _ctx, state) do
-    {kind, _pts} = Enum.min_by(state.last_pts, fn {_kind, pts} -> pts end)
+  def handle_info(:boombox_demand, ctx, state) do
+    {kind, _pts} =
+      state.last_pts
+      |> Enum.reject(fn {kind, _pts} -> ctx.pads[Pad.ref(:input, kind)].end_of_stream? end)
+      |> Enum.min_by(fn {_kind, pts} -> pts end)
+
     {[demand: Pad.ref(:input, kind)], state}
   end
 

--- a/lib/boombox/internal_bin/elixir_stream/source.ex
+++ b/lib/boombox/internal_bin/elixir_stream/source.ex
@@ -1,8 +1,4 @@
-<<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream/source.ex
 defmodule Boombox.InternalBin.ElixirStream.Source do
-========
-defmodule Boombox.ElixirStream.Source do
->>>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream/source.ex
   @moduledoc false
   use Membrane.Source
 

--- a/lib/boombox/internal_bin/elixir_stream/source.ex
+++ b/lib/boombox/internal_bin/elixir_stream/source.ex
@@ -79,17 +79,17 @@ defmodule Boombox.InternalBin.ElixirStream.Source do
     %Boombox.Packet{payload: payload, format: format} = packet
     buffer = %Membrane.Buffer{payload: payload, pts: packet.pts}
 
-    case {format, state.audio_format} do
-      {empty_format, nil} when empty_format == %{} ->
+    case format do
+      empty_format when empty_format == %{} and state.audio_format == nil ->
         raise "No audio stream format provided"
 
-      {empty_format, _state_audio_format} when empty_format == %{} ->
+      empty_format when empty_format == %{} ->
         {[buffer: {Pad.ref(:output, :audio), buffer}], state}
 
-      {unchanged_format, unchanged_format} ->
+      unchanged_format when unchanged_format == state.audio_format ->
         {[buffer: {Pad.ref(:output, :audio), buffer}], state}
 
-      {new_format, _old_format} ->
+      new_format ->
         stream_format = %Membrane.RawAudio{
           sample_format: new_format.audio_format,
           sample_rate: new_format.audio_rate,

--- a/lib/boombox/internal_bin/elixir_stream/source.ex
+++ b/lib/boombox/internal_bin/elixir_stream/source.ex
@@ -1,4 +1,8 @@
+<<<<<<<< HEAD:lib/boombox/internal_bin/elixir_stream/source.ex
 defmodule Boombox.InternalBin.ElixirStream.Source do
+========
+defmodule Boombox.ElixirStream.Source do
+>>>>>>>> 5914bea (Fix for release, go back to elixir_stream):lib/boombox/elixir_stream/source.ex
   @moduledoc false
   use Membrane.Source
 

--- a/lib/boombox/internal_bin/elixir_stream/source.ex
+++ b/lib/boombox/internal_bin/elixir_stream/source.ex
@@ -10,22 +10,13 @@ defmodule Boombox.InternalBin.ElixirStream.Source do
 
   def_options producer: [
                 spec: pid()
-              ],
-              audio_options: [
-                spec:
-                  %{
-                    audio_format: Membrane.RawAudio.SampleFormat.t(),
-                    audio_rate: Membrane.RawAudio.sample_rate_t(),
-                    audio_channels: Membrane.RawAudio.channels_t()
-                  }
-                  | nil
               ]
 
   @impl true
   def handle_init(_ctx, opts) do
     state = %{
       producer: opts.producer,
-      audio_format: opts.audio_options,
+      audio_format: nil,
       video_dims: nil
     }
 

--- a/lib/boombox/internal_bin/elixir_stream/source.ex
+++ b/lib/boombox/internal_bin/elixir_stream/source.ex
@@ -12,11 +12,27 @@ defmodule Boombox.ElixirStream.Source do
     flow_control: :manual,
     demand_unit: :buffers
 
-  def_options producer: [spec: pid()]
+  def_options producer: [
+                spec: pid()
+              ],
+              audio_options: [
+                spec:
+                  %{
+                    audio_format: Membrane.RawAudio.SampleFormat.t(),
+                    audio_rate: Membrane.RawAudio.sample_rate_t(),
+                    audio_channels: Membrane.RawAudio.channels_t()
+                  }
+                  | nil
+              ]
 
   @impl true
   def handle_init(_ctx, opts) do
-    state = Map.merge(Map.from_struct(opts), %{video_dims: nil, audio_format: nil})
+    state = %{
+      producer: opts.producer,
+      audio_format: opts.audio_options,
+      video_dims: nil
+    }
+
     {[], state}
   end
 
@@ -67,19 +83,27 @@ defmodule Boombox.ElixirStream.Source do
     %Boombox.Packet{payload: payload, format: format} = packet
     buffer = %Membrane.Buffer{payload: payload, pts: packet.pts}
 
-    if format == state.audio_format do
-      {[buffer: {Pad.ref(:output, :audio), buffer}], state}
-    else
-      stream_format = %Membrane.RawAudio{
-        sample_format: format.audio_format,
-        sample_rate: format.audio_rate,
-        channels: format.audio_channels
-      }
+    case {format, state.audio_format} do
+      {empty_format, nil} when empty_format == %{} ->
+        raise "No audio stream format provided"
 
-      {[
-         stream_format: {Pad.ref(:output, :audio), stream_format},
-         buffer: {Pad.ref(:output, :audio), buffer}
-       ], %{state | audio_format: format}}
+      {empty_format, _state_audio_format} when empty_format == %{} ->
+        {[buffer: {Pad.ref(:output, :audio), buffer}], state}
+
+      {unchanged_format, unchanged_format} ->
+        {[buffer: {Pad.ref(:output, :audio), buffer}], state}
+
+      {new_format, _old_format} ->
+        stream_format = %Membrane.RawAudio{
+          sample_format: new_format.audio_format,
+          sample_rate: new_format.audio_rate,
+          channels: new_format.audio_channels
+        }
+
+        {[
+           stream_format: {Pad.ref(:output, :audio), stream_format},
+           buffer: {Pad.ref(:output, :audio), buffer}
+         ], %{state | audio_format: format}}
     end
   end
 

--- a/lib/boombox/internal_bin/hls.ex
+++ b/lib/boombox/internal_bin/hls.ex
@@ -50,7 +50,6 @@ defmodule Boombox.InternalBin.HLS do
               output_stream_format: Membrane.AAC,
               transcoding_policy: transcoding_policy
             })
-            |> child(:hls_audio_realtimer, Membrane.Realtimer)
             |> via_in(Pad.ref(:input, :audio),
               options: [encoding: :AAC, segment_duration: Time.milliseconds(2000)]
             )
@@ -62,7 +61,6 @@ defmodule Boombox.InternalBin.HLS do
               output_stream_format: %H264{alignment: :au, stream_structure: :avc3},
               transcoding_policy: transcoding_policy
             })
-            |> child(:hls_video_realtimer, Membrane.Realtimer)
             |> via_in(Pad.ref(:input, :video),
               options: [encoding: :H264, segment_duration: Time.milliseconds(2000)]
             )

--- a/lib/boombox/internal_bin/hls.ex
+++ b/lib/boombox/internal_bin/hls.ex
@@ -50,6 +50,7 @@ defmodule Boombox.InternalBin.HLS do
               output_stream_format: Membrane.AAC,
               transcoding_policy: transcoding_policy
             })
+            |> child(:hls_audio_realtimer, Membrane.Realtimer)
             |> via_in(Pad.ref(:input, :audio),
               options: [encoding: :AAC, segment_duration: Time.milliseconds(2000)]
             )
@@ -61,6 +62,7 @@ defmodule Boombox.InternalBin.HLS do
               output_stream_format: %H264{alignment: :au, stream_structure: :avc3},
               transcoding_policy: transcoding_policy
             })
+            |> child(:hls_video_realtimer, Membrane.Realtimer)
             |> via_in(Pad.ref(:input, :video),
               options: [encoding: :H264, segment_duration: Time.milliseconds(2000)]
             )

--- a/lib/boombox/server.ex
+++ b/lib/boombox/server.ex
@@ -1,20 +1,20 @@
 defmodule Boombox.Server do
-  @moduledoc """
-  This module provides a GenServer interface for Boombox. To run Boombox the server needs to be
-  called with `{:run, boombox_opts}` - it can be done by calling `run/2`, sending a
-  `{:call, :run, boombox_opts}` message to the server or calling the server directly with
-  `GenServer.call/3`. The return value signals what mode Boombox is in. Once Boombox is running
-  it can be interacted with through appropriate functions, GenServer calls and messages:
-    * Function calls - `consume_packet/2`, `finish_consuming/1` and `produce_packet/1` are functions
-                       that can be used for communication with the server.
-    * GenServer calls - `{:consume_packet, packet}`, `:finish_consuming` and `:produce_packet` are
-                        terms that the server can be called with. These calls will behave the same
-                        way as their respective functions mentioned above.
-    * Messages - `{:call, sender, {:consume_packet, packet}}`, `{:call, sender, :finish_consuming}`
-                 and `{:call, sender, :produce_packet}` messages will cause the server to handle the
-                 call specified by the third element of the tuple and send the result to `sender`
-                 when finished.
-  """
+  @moduledoc false
+  # This module provides a GenServer interface for Boombox. To run Boombox the server needs to be
+  # called with `{:run, boombox_opts}` - it can be done by calling `run/2`, sending a
+  # `{:call, :run, boombox_opts}` message to the server or calling the server directly with
+  # `GenServer.call/3`. The return value signals what mode Boombox is in. Once Boombox is running
+  # it can be interacted with through appropriate functions, GenServer calls and messages:
+  #   * Function calls - `consume_packet/2`, `finish_consuming/1` and `produce_packet/1` are functions
+  #                      that can be used for communication with the server.
+  #   * GenServer calls - `{:consume_packet, packet}`, `:finish_consuming` and `:produce_packet` are
+  #                        terms that the server can be called with. These calls will behave the same
+  #                        way as their respective functions mentioned above.
+  #   * Messages - `{:call, sender, {:consume_packet, packet}}`, `{:call, sender, :finish_consuming}`
+  #                and `{:call, sender, :produce_packet}` messages will cause the server to handle the
+  #                call specified by the third element of the tuple and send the result to `sender`
+  #                when finished.
+
   use GenServer
 
   require Logger

--- a/lib/boombox/server.ex
+++ b/lib/boombox/server.ex
@@ -1,0 +1,256 @@
+defmodule Boombox.Server do
+  require Logger
+  use GenServer
+
+  alias Membrane.RTCP.Packet
+  alias Boombox.Packet
+
+  @typep boombox_opts :: [input: Boombox.input(), output: Boombox.output()]
+  @typep boombox_mode :: :consuming | :producing | :standalone
+
+  @type serialized_audio_data :: %{
+          data: binary(),
+          sample_format: Membrane.RawAudio.SampleFormat.t(),
+          sample_rate: pos_integer(),
+          channels: pos_integer()
+        }
+  @type serialized_video_data :: %{
+          data: binary(),
+          width: pos_integer(),
+          height: pos_integer(),
+          channels: pos_integer()
+        }
+  @type serialized_packet :: %{
+          payload: {:audio, serialized_audio_data()} | {:video, serialized_video_data()},
+          timestamp: integer()
+        }
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(arg) do
+    GenServer.start_link(__MODULE__, arg)
+  end
+
+  @spec start(term()) :: GenServer.on_start()
+  def start(arg) do
+    GenServer.start(__MODULE__, arg)
+  end
+
+  @impl true
+  def init(_arg) do
+    Process.register(self(), :boombox_server)
+    {:ok, %{boombox_pid: nil, boombox_monitor: nil, last_produced_packet: nil}}
+  end
+
+  @impl true
+  def handle_call({:run_boombox, run_opts}, _from, state) do
+    boombox_mode = get_boombox_mode(run_opts)
+    server_pid = self()
+
+    boombox_process_fun =
+      case boombox_mode do
+        :consuming -> fn -> consuming_boombox_function(run_opts, server_pid) end
+        :producing -> fn -> producing_boombox_function(run_opts, server_pid) end
+        :standalone -> fn -> standalone_boombox_function(run_opts) end
+      end
+
+    boombox_pid = spawn(boombox_process_fun)
+    Process.monitor(boombox_pid)
+
+    last_produced_packet =
+      case boombox_mode do
+        :consuming ->
+          receive do
+            :packet_consumed -> nil
+          end
+
+        :producing ->
+          receive do
+            {:packet_produced, packet} -> packet
+          end
+
+        :standalone ->
+          nil
+      end
+
+    {:reply, :ok, %{state | boombox_pid: boombox_pid, last_produced_packet: last_produced_packet}}
+  end
+
+  @impl true
+  def handle_call(:get_pid, _from, state) do
+    {:reply, self(), state}
+  end
+
+  @impl true
+  def handle_call({:consume_packet, packet}, _from, state) do
+    packet = deserialize_packet(packet)
+    send(state.boombox_pid, {:consume_packet, packet})
+
+    receive do
+      :packet_consumed ->
+        {:reply, :ok, state}
+
+      :finished ->
+        {:reply, :finished, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:finish_consuming, _from, state) do
+    send(state.boombox_pid, :finish_consuming)
+
+    receive do
+      :finished ->
+        {:reply, :finished, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:produce_packet, _from, state) do
+    send(state.boombox_pid, :produce_packet)
+
+    last_produced_packet = state.last_produced_packet
+
+    {production_phase, state} =
+      receive do
+        {:packet_produced, packet} -> {:continue, %{state | last_produced_packet: packet}}
+        :finished -> {:finished, state}
+      end
+
+    serialized_packet = serialize_packet(last_produced_packet)
+    {:reply, {production_phase, serialized_packet}, state}
+  end
+
+  @impl true
+  def handle_info({:call, sender, message}, state) do
+    {:reply, reply, state} = handle_call(message, sender, state)
+    send(sender, reply)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, :normal}, %{boombox_pid: pid} = state) do
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_info(info, state) do
+    Logger.warning("Ignoring message #{inspect(info)}")
+    {:noreply, state}
+  end
+
+  @spec deserialize_packet(serialized_packet()) :: Packet.t()
+  defp deserialize_packet(%{payload: {:audio, payload}} = serialized_packet) do
+    %Boombox.Packet{
+      kind: :audio,
+      payload: payload.data,
+      pts: Membrane.Time.milliseconds(serialized_packet.timestamp),
+      format: %{
+        audio_format: payload.sample_format,
+        audio_rate: payload.sample_rate,
+        audio_channels: payload.channels
+      }
+    }
+  end
+
+  defp deserialize_packet(%{payload: {:video, payload}} = serialized_packet) do
+    {:ok, img} =
+      Vix.Vips.Image.new_from_binary(
+        payload.data,
+        payload.width,
+        payload.height,
+        payload.channels,
+        :VIPS_FORMAT_UCHAR
+      )
+
+    %Boombox.Packet{
+      kind: :video,
+      payload: img,
+      pts: Membrane.Time.milliseconds(serialized_packet.timestamp)
+    }
+  end
+
+  @spec serialize_packet(Packet.t()) :: serialized_packet()
+  defp serialize_packet(%Packet{kind: :audio} = packet) do
+    serialized_payload =
+      {:audio,
+       %{
+         data: packet.payload,
+         sample_format: packet.format.audio_format,
+         sample_rate: packet.format.audio_rate,
+         channels: packet.format.audio_channels
+       }}
+
+    %{
+      payload: serialized_payload,
+      timestamp: Membrane.Time.as_milliseconds(packet.pts, :round)
+    }
+  end
+
+  defp serialize_packet(%Packet{kind: :video} = packet) do
+    {:ok, tensor} = Vix.Vips.Image.write_to_tensor(packet.payload)
+    {height, width, channels} = tensor.shape
+
+    serialized_payload =
+      {:video,
+       %{
+         data: tensor.data,
+         width: width,
+         height: height,
+         channels: channels
+       }}
+
+    %{
+      payload: serialized_payload,
+      timestamp: Membrane.Time.as_milliseconds(packet.pts, :round)
+    }
+  end
+
+  @spec consuming_boombox_function(boombox_opts(), pid()) :: :ok
+  defp consuming_boombox_function(run_opts, server_pid) do
+    Stream.resource(
+      fn -> nil end,
+      fn nil ->
+        send(server_pid, :packet_consumed)
+
+        receive do
+          {:consume_packet, packet} ->
+            {[packet], nil}
+
+          :finish_consuming ->
+            {:halt, nil}
+        end
+      end,
+      fn nil -> send(server_pid, :finished) end
+    )
+    |> Boombox.run(run_opts)
+  end
+
+  @spec producing_boombox_function(boombox_opts(), pid()) :: :ok
+  defp producing_boombox_function(run_opts, server_pid) do
+    Boombox.run(run_opts)
+    |> Enum.each(fn packet ->
+      send(server_pid, {:packet_produced, packet})
+
+      receive do
+        :produce_packet -> :ok
+      end
+    end)
+
+    send(server_pid, :finished)
+  end
+
+  @spec standalone_boombox_function(boombox_opts()) :: :ok
+  defp standalone_boombox_function(run_opts) do
+    Boombox.run(run_opts)
+  end
+
+  @spec get_boombox_mode(input: Boombox.input(), output: Boombox.output()) :: boombox_mode()
+  defp get_boombox_mode(run_opts) do
+    case Map.new(run_opts) do
+      %{input: {:stream, _input_opts}, output: {:stream, _output_opts}} -> raise "Cannot do both"
+      %{input: {:stream, _input_opts}} -> :consuming
+      %{output: {:stream, _output_opts}} -> :producing
+      _neither_input_or_output -> :standalone
+    end
+  end
+end

--- a/lib/boombox/server.ex
+++ b/lib/boombox/server.ex
@@ -252,7 +252,7 @@ defmodule Boombox.Server do
   end
 
   defp handle_request(:get_pid, state) do
-    {:reply, self(), state}
+    {self(), state}
   end
 
   defp handle_request(

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Boombox.Mixfile do
         if burrito?() do
           {Boombox.Utils.BurritoApp, []}
         else
-          []
+          {Boombox.Application, []}
         end
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -150,8 +150,10 @@ defmodule Boombox.Mixfile do
       boombox:
         [
           steps: [:assemble, &restore_symlinks/1, burrito_wrap]
-        ] ++
-          burrito_config
+        ] ++ burrito_config,
+      boombox_python: [
+        steps: [:assemble, &restore_symlinks/1]
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -151,7 +151,7 @@ defmodule Boombox.Mixfile do
         [
           steps: [:assemble, &restore_symlinks/1, burrito_wrap]
         ] ++ burrito_config,
-      boombox_python: [
+      server: [
         steps: [:assemble, &restore_symlinks/1]
       ]
     ]


### PR DESCRIPTION
### This PR:
- Adds a Realtimer before HLS sink, since when the packets came in faster than in real time the sink deleted the segments too quickly.
- Fixes a bug where an elixir stream sink could demand on a pad with eos and never get a buffer and never responding to the demanding process, effectively bricking the generator.
- Makes that if the user passed audio options to the `:stream` input they are passed to the `ElixirStream.Source`. 
- Improved handling of audio format in `ElixirStream.Source` - remembering last format, either passed via options or received in a `Boombox.Packet`, and sending stream format if the format changed.
- Add an Application specification that runs `Boombox.Server` when running a `server` release
- Adds a standalone server, `Boombox.Server`, that allows for running Boombox in a separate process and communicate with it through synchronous functions, GenServer calls and functions.
### To do:
- Tests
- Consider whether consuming and producing is the best nomenclature, maybe regular read, write and close could be clearer