### PR TITLE
feat(rtsp): allow configuring the RTSP transport

### DIFF
--- a/lib/boombox/endpoints.ex
+++ b/lib/boombox/endpoints.ex
@@ -405,8 +405,18 @@ defmodule Boombox.Endpoints do
     Defaults to `[:video, :audio]`. Pass `[:video]` to skip audio entirely,
     which is useful for surveillance cameras that publish unsupported audio
     codecs (e.g. PCMA/PCMU).
+
+  * `:transport` — how the server should send the media. Defaults to a UDP
+    port range, which `Membrane.RTSP.Source` reads as
+    `{:udp, port_range_start, port_range_end}`. Pass `:tcp` to interleave the
+    media on the control connection instead, which some NVRs need and some
+    networks require. Note that `Membrane.RTSP.Source`'s own default is
+    `:tcp`; Boombox defaults to UDP because for live video a lost datagram
+    costs one frame, while TCP's head-of-line blocking costs latency.
   """
-  @type rtsp_input_opt :: {:allowed_media_types, [:video | :audio | :application]}
+  @type rtsp_input_opt ::
+          {:allowed_media_types, [:video | :audio | :application]}
+          | {:transport, Membrane.RTSP.Source.transport()}
 
   @typedoc """
   RTSP (Real-Time Streaming Protocol) input endpoint.

--- a/lib/boombox/internal_bin/rtsp.ex
+++ b/lib/boombox/internal_bin/rtsp.ex
@@ -14,10 +14,11 @@ defmodule Boombox.InternalBin.RTSP do
   def create_input(uri, opts) do
     port = Enum.random(5_000..65_000)
     allowed_media_types = Keyword.get(opts, :allowed_media_types, @default_allowed_media_types)
+    transport = Keyword.get(opts, :transport, {:udp, port, port + 20})
 
     spec =
       child(:rtsp_source, %RTSP.Source{
-        transport: {:udp, port, port + 20},
+        transport: transport,
         allowed_media_types: allowed_media_types,
         stream_uri: uri,
         on_connection_closed: :send_eos

--- a/test/boombox_internal_bin_rtsp_test.exs
+++ b/test/boombox_internal_bin_rtsp_test.exs
@@ -19,6 +19,17 @@ defmodule Boombox.InternalBin.RTSPTest do
 
       assert allowed_media_types(spec) == [:video]
     end
+
+    test "defaults to a UDP port range when no transport is given" do
+      assert %Wait{actions: [spec: spec]} = RTSP.create_input(@uri, [])
+      assert {:udp, from, to} = transport(spec)
+      assert to == from + 20
+    end
+
+    test "threads transport through to the RTSP source" do
+      assert %Wait{actions: [spec: spec]} = RTSP.create_input(@uri, transport: :tcp)
+      assert transport(spec) == :tcp
+    end
   end
 
   describe "handle_set_up_tracks/2" do
@@ -79,6 +90,11 @@ defmodule Boombox.InternalBin.RTSPTest do
   defp allowed_media_types(%Membrane.ChildrenSpec.Builder{} = spec) do
     [{:rtsp_source, %Membrane.RTSP.Source{allowed_media_types: types}, _opts}] = spec.children
     types
+  end
+
+  defp transport(%Membrane.ChildrenSpec.Builder{} = spec) do
+    [{:rtsp_source, %Membrane.RTSP.Source{transport: transport}, _opts}] = spec.children
+    transport
   end
 
   defp find_child(spec, name) do


### PR DESCRIPTION
## Problem

`Membrane.RTSP.Source` takes a `transport` option and defaults it to `:tcp`
(`membrane_rtsp_plugin/lib/membrane_rtsp_plugin/source.ex:54`).
`Boombox.InternalBin.RTSP.create_input/2` overrides that with a random UDP port
range and reads no option that would change it, so a caller who needs TCP has
no way to ask for it.

Two situations where that matters: an NVR that mis-assembles fragmented H.265
over UDP, and a network that drops the media ports while leaving 554 open.

Nothing currently rejects a stray key either — `{:rtsp, url, opts}` is accepted
on `is_list(opts)` alone — so a caller who passes `transport: :tcp` today gets
no error and no effect.

## Change

Read `:transport` from the options list, defaulting to the existing UDP range
so nothing changes for existing callers.

```elixir
transport = Keyword.get(opts, :transport, {:udp, port, port + 20})
```

Plus the `rtsp_input_opt` typedoc and two tests alongside the existing
`allowed_media_types` ones.

## On the default

It disagrees with the element below it, so it seemed worth documenting rather
than quietly matching. For live video a lost datagram costs one frame and the
stream self-heals at the next keyframe, while TCP interleaves media on the
control socket, so the same loss becomes head-of-line blocking and then
latency. Neither is right for every caller, which is the argument for an
option rather than for flipping the default. I have left the default alone.

## Verified

`mix test test/boombox_internal_bin_rtsp_test.exs` — 7 tests, 0 failures.

End to end against `mediamtx` v1.9.3 carrying a real H.265 stream, reading the
transport off the server rather than off the option:

```
[RTSP] [session 51231494] is reading from path 'cam265', with UDP, 1 track (H265)   # default
[RTSP] [session 46d6f227] is reading from path 'cam265', with TCP, 1 track (H265)   # transport: :tcp
```